### PR TITLE
pyscanfcs/openfile.py: fix for numpy 2.0.

### DIFF
--- a/pyscanfcs/openfile.py
+++ b/pyscanfcs/openfile.py
@@ -95,7 +95,7 @@ def openDAT(path, callback=None, cb_kwargs={}):
 
         # Make a 32 bit array
         data = np.uint32(data16)
-        data[occ] = data16[occ + 1] + data16[occ + 2] * 65536
+        data[occ] = data[occ + 1] + data[occ + 2] * 65536
 
         if callback is not None:
             ret = callback(**cb_kwargs)


### PR DESCRIPTION
As initially identified in [Debian bug #1095368], test_open_dat fails with numpy 2.0 and beyond with the following error:

	            # Make a 32 bit array
	            data = np.uint32(data16)
	>           data[occ] = data16[occ + 1] + data16[occ + 2] * 65536
	E           OverflowError: Python integer 65536 out of bounds for uint16

This change uses the freshly converted data array to uint32 for the data concatenation instead of using the uint16 data16 array elements.

[Debian bug #1095368]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1095368